### PR TITLE
Add initial support for secondary palette

### DIFF
--- a/source/FakoBios.h
+++ b/source/FakoBios.h
@@ -79,7 +79,12 @@ function _update60()
 	
 	if cidx > 0 and cidx <= numcarts then
 		carttoload = carts[cidx]
-		linebuffer = "load " .. carttoload
+		local lastslashidx = string.find(carttoload, "/[^/]*$")
+		local dispstr = carttoload
+		if lastslashidx > 0 then
+			dispstr = sub(dispstr, lastslashidx + 1)
+		end
+		linebuffer = "load " .. dispstr
 	else
 		carttoload = ""
 	end

--- a/source/FakoBios.h
+++ b/source/FakoBios.h
@@ -37,7 +37,7 @@ function _init()
 	cursor(0, 6*3)
 	print("welcome to fake-08")
 	print("a homebrew pico-8 emulator")
-	print("currently in alpha (v0.0.2)")
+	print("currently in alpha (v0.0.2.2)")
 	print("")
 	print("place p8 carts in sdmc:/p8carts/")
 	if numcarts < 1 then

--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -45,6 +45,27 @@ Graphics::Graphics(std::string fontdata, PicoRam* memory) {
 	_paletteColors[14] = COLOR_14;
 	_paletteColors[15] = COLOR_15;
 
+	for (int i = 16; i < 128; i++) {
+		_paletteColors[i] = {0, 0, 0, 0};
+	}
+
+	_paletteColors[128] = COLOR_128;
+	_paletteColors[129] = COLOR_129;
+	_paletteColors[130] = COLOR_130;
+	_paletteColors[131] = COLOR_131;
+	_paletteColors[132] = COLOR_132;
+	_paletteColors[133] = COLOR_133;
+	_paletteColors[134] = COLOR_134;
+	_paletteColors[135] = COLOR_135;
+	_paletteColors[136] = COLOR_136;
+	_paletteColors[137] = COLOR_137;
+	_paletteColors[138] = COLOR_138;
+	_paletteColors[139] = COLOR_139;
+	_paletteColors[140] = COLOR_140;
+	_paletteColors[141] = COLOR_141;
+	_paletteColors[142] = COLOR_142;
+	_paletteColors[143] = COLOR_143;
+
 	//set default clip
 	clip();
 	pal();
@@ -306,18 +327,18 @@ bool Graphics::isOnScreen(int x, int y) {
 }
 
 bool Graphics::isColorTransparent(uint8_t color) {
-	color = color & 15;
+	color = color & 0x0f;
 	return (_memory->drawState.drawPaletteMap[color] >> 4) & 1U; //4th bit is transparency
 }
 
 uint8_t Graphics::getDrawPalMappedColor(uint8_t color) {
-	color = color & 15;
-	return _memory->drawState.drawPaletteMap[color] & 15; //bits 0-3 are color
+	color = color & 0x0f;
+	return _memory->drawState.drawPaletteMap[color] & 0x0f; //bits 0-3 are color
 }
 
 uint8_t Graphics::getScreenPalMappedColor(uint8_t color) {
-	color = color & 15;
-	return _memory->drawState.screenPaletteMap[color] & 15;
+	color = color & 0x0f;
+	return _memory->drawState.screenPaletteMap[color] & 0x8f;
 }
 
 bool Graphics::isWithinClip(int x, int y) {
@@ -1096,13 +1117,15 @@ void Graphics::pal() {
 }
 
 void Graphics::pal(uint8_t c0, uint8_t c1, uint8_t p){
-	if (c0 < 16 && c1 < 16) {
-		if (p == 0) {
-			//for draw palette we have to preserve the transparency bit
-			_memory->drawState.drawPaletteMap[c0] = (_memory->drawState.drawPaletteMap[c0] & 0x10) | (c1 & 0xf);
-		} else if (p == 1) {
-			_memory->drawState.screenPaletteMap[c0] = c1;
-		}
+	//0-15 alowed
+	c0 &= 0x0f;
+	if (p == 0) {
+		//for draw palette we have to preserve the transparency bit
+		_memory->drawState.drawPaletteMap[c0] = (_memory->drawState.drawPaletteMap[c0] & 0x10) | (c1 & 0xf);
+	} else if (p == 1) {
+		//0-15, or 127-143 allowed
+		c1 &= 0x8f;
+		_memory->drawState.screenPaletteMap[c0] = c1;
 	}
 }
 

--- a/source/graphics.h
+++ b/source/graphics.h
@@ -47,7 +47,7 @@ using namespace z8;
 class Graphics {
 	uint8_t fontSpriteData[128 * 64];
 
-	Color _paletteColors[16];
+	Color _paletteColors[144];
 
 	PicoRam* _memory;
 

--- a/source/graphics.h
+++ b/source/graphics.h
@@ -23,6 +23,24 @@ using namespace z8;
 #define COLOR_14 {255, 119, 168, 255}
 #define COLOR_15 {255, 204, 170, 255}
 
+//alt palette
+#define COLOR_128 { 41,  24,  20, 255}
+#define COLOR_129 { 17,  29,  53, 255}
+#define COLOR_130 { 66,  33,  54, 255}
+#define COLOR_131 { 18,  83,  89, 255}
+#define COLOR_132 {116,  47,  41, 255}
+#define COLOR_133 { 73,  51,  59, 255}
+#define COLOR_134 {162, 136, 121, 255}
+#define COLOR_135 {243, 239, 125, 255}
+#define COLOR_136 {190,  18,  80, 255}
+#define COLOR_137 {255, 108,  36, 255}
+#define COLOR_138 {168, 231,  46, 255}
+#define COLOR_139 {  0, 181,  67, 255}
+#define COLOR_140 {  6,  90, 181, 255}
+#define COLOR_141 {117,  70, 101, 255}
+#define COLOR_142 {255, 110,  89, 255}
+#define COLOR_143 {255, 157, 129, 255}
+
 #define BG_GRAY_COLOR {128, 128, 128, 255}
 
 

--- a/test/graphicstests.cpp
+++ b/test/graphicstests.cpp
@@ -1579,6 +1579,20 @@ TEST_CASE("graphics class behaves as expected") {
 
         CHECK_EQ(4, result);
     }
+    SUBCASE("pal({c0}, {c1}, {p}) 17 remapped to 1") {
+        graphics->pal(13, 17, 1);
+
+        auto result = graphics->getScreenPalMappedColor(13);
+
+        CHECK_EQ(1, result);
+    }
+    SUBCASE("pal({c0}, {c1}, {p}) extended palette allowed") {
+        graphics->pal(7, 143, 1);
+
+        auto result = graphics->getScreenPalMappedColor(7);
+
+        CHECK_EQ(143, result);
+    }
     SUBCASE("palt({c}, {t}) sets transparency value for color") {
         graphics->palt(2, true);
 


### PR DESCRIPTION
Adds support for the 16 alternate colors in the screen palette (pal(c0, c1, 1)).


updates bios to not show folder name of files so more of the filename can be seen