### PR TITLE
Optimize writing to 3ds framebuffer

### DIFF
--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -20,8 +20,6 @@ using namespace z8;
 const uint8_t PicoScreenWidth = 128;
 const uint8_t PicoScreenHeight = 128;
 
-const Color BgGray = BG_GRAY_COLOR;
-
 
 //call initialize to make sure defaults are correct
 Graphics::Graphics(std::string fontdata, PicoRam* memory) {

--- a/source/graphics.h
+++ b/source/graphics.h
@@ -41,8 +41,6 @@ using namespace z8;
 #define COLOR_142 {255, 110,  89, 255}
 #define COLOR_143 {255, 157, 129, 255}
 
-#define BG_GRAY_COLOR {128, 128, 128, 255}
-
 
 class Graphics {
 	uint8_t fontSpriteData[128 * 64];


### PR DESCRIPTION
only clear the both framebuffers completely on init, and then use RGB565 (16 bit) instead of RGB888 (24 bit) to transfer. Slightly loss in color fidelity, but worth it for a little speed up.