### PR TITLE
Implement non-mirrored draw modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export APP_AUTHOR	= jtothebell
 export V_MAJOR	= 0
 export V_MINOR	= 0
 export V_PATCH	= 2
-export V_BUILD	= 7
+export V_BUILD	= 8
 export APP_VERSION	= v$(V_MAJOR).$(V_MINOR).$(V_PATCH).$(V_BUILD)
 
 

--- a/platform/3ds/Makefile
+++ b/platform/3ds/Makefile
@@ -66,7 +66,7 @@ CC = $(CXX)
 
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-CFLAGS	:=	-g -Wall -O2 -mword-relocations \
+CFLAGS	:=	-g -Wall -Ofast -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
 

--- a/platform/3ds/Makefile
+++ b/platform/3ds/Makefile
@@ -66,7 +66,7 @@ CC = $(CXX)
 
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-CFLAGS	:=	-g -Wall -Ofast -mword-relocations \
+CFLAGS	:=	-g -Wall -O2 -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
 
@@ -77,7 +77,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fexceptions -std=gnu++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lctru -lm
+LIBS	:= -lcitro2d -lcitro3d -lctru -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/platform/3ds/source/3dsHost.cpp
+++ b/platform/3ds/source/3dsHost.cpp
@@ -493,7 +493,7 @@ void Host::waitForTargetFps(){
 }
 
 
-void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenMode){
+void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t drawMode){
     size_t pixIdx = 0;
 
     for (pixIdx = 0; pixIdx < pico_pixel_buffer_size; pixIdx++){
@@ -517,7 +517,7 @@ void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenM
     flipHorizontal = 1;
     flipVertical = 1;
 
-    switch(screenMode){
+    switch(drawMode){
         case 1:
             screenModeScaleX = 2.0f;
             screenModeScaleY = 1.0f;

--- a/platform/3ds/source/3dsHost.cpp
+++ b/platform/3ds/source/3dsHost.cpp
@@ -65,12 +65,12 @@ Tex3DS_SubTexture *pico_subtex;
 C3D_RenderTarget* topTarget;
 C3D_RenderTarget* bottomTarget;
 
-u32* pico_pixel_buffer;
+u16* pico_pixel_buffer;
 
-const GPU_TEXCOLOR texColor = GPU_RGBA8;
+const GPU_TEXCOLOR texColor = GPU_RGB565;
 
 #define CLEAR_COLOR 0xFF000000
-#define BYTES_PER_PIXEL 4
+#define BYTES_PER_PIXEL 2
 size_t pico_rgba_buffer_size = 128*128*BYTES_PER_PIXEL;
 
 u32 clrRec1;
@@ -270,7 +270,7 @@ void Host::oneTimeSetup(Color* paletteColors, Audio* audio){
 	pico_image.tex = pico_tex;
 	pico_image.subtex = pico_subtex;
 
-	pico_pixel_buffer = (u32*)linearAlloc(pico_rgba_buffer_size);
+	pico_pixel_buffer = (u16*)linearAlloc(pico_rgba_buffer_size);
 
     clrRec1 = C2D_Color32(0x9A, 0x6C, 0xB9, 0xFF);
 
@@ -415,7 +415,7 @@ void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap){
         //uint8_t lc = getPixelNibble(x, y, picoFb);
         //uint16_t lcol = _rgb565Colors[screenPaletteMap[lc]];
         //u32 lcol = _rgba8Colors[screenPaletteMap[lc]];
-        pico_pixel_buffer[pixIdx] = _rgba8Colors[screenPaletteMap[getPixelNibble(x, y, picoFb)]];
+        pico_pixel_buffer[pixIdx] = _rgb565Colors[screenPaletteMap[getPixelNibble(x, y, picoFb)]];
     }
 
     /*
@@ -444,7 +444,7 @@ void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap){
         (u32*)pico_pixel_buffer, GX_BUFFER_DIM(128, 128),
         (u32*)(pico_tex->data), GX_BUFFER_DIM(128, 128),
 		(GX_TRANSFER_FLIP_VERT(0) | GX_TRANSFER_OUT_TILED(1) | GX_TRANSFER_RAW_COPY(0) |
-        GX_TRANSFER_IN_FORMAT(GX_TRANSFER_FMT_RGBA8) | GX_TRANSFER_OUT_FORMAT(GX_TRANSFER_FMT_RGBA8) |
+        GX_TRANSFER_IN_FORMAT(GX_TRANSFER_FMT_RGB565) | GX_TRANSFER_OUT_FORMAT(GX_TRANSFER_FMT_RGB565) |
         GX_TRANSFER_SCALING(GX_TRANSFER_SCALE_NO))
     );
 

--- a/platform/SDL2Common/source/sdl2basehost.cpp
+++ b/platform/SDL2Common/source/sdl2basehost.cpp
@@ -60,6 +60,9 @@ uint8_t *base;
 int pitch;
 
 SDL_Rect DestR;
+SDL_Rect SrcR;
+double textureAngle;
+SDL_RendererFlip flip;
 
 int joystickCount = 0;
 
@@ -69,7 +72,7 @@ bool audioInitialized = false;
 void postFlipFunction(){
     // We're done rendering, so we end the frame here.
     SDL_UnlockTexture(texture);
-    SDL_RenderCopy(renderer, texture, NULL, &DestR);
+    SDL_RenderCopyEx(renderer, texture, &SrcR, &DestR, textureAngle, NULL, flip);
 
     SDL_RenderPresent(renderer);
 }
@@ -132,6 +135,14 @@ void _changeStretch(StretchOption newStretch){
     DestR.y = _windowHeight / 2 - _screenHeight / 2;
     DestR.w = _screenWidth;
     DestR.h = _screenHeight;
+
+    SrcR.x = 0;
+    SrcR.y = 0;
+    SrcR.w = PicoScreenWidth;
+    SrcR.h = PicoScreenHeight;
+
+    textureAngle = 0;
+    flip = SDL_FLIP_NONE;
 }
 
 void Host::setPlatformParams(
@@ -287,7 +298,7 @@ void Host::waitForTargetFps(){
 }
 
 
-void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap){
+void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenMode){
     //clear screen to all black
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
@@ -305,6 +316,74 @@ void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap){
             base[2] = col.Red;
             base[3] = col.Alpha;
         }
+    }
+
+    SrcR.x = 0;
+    SrcR.y = 0;
+
+    switch(screenMode){
+        case 1:
+            SrcR.w = 64;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 2:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = 64;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 3:
+            SrcR.w = 64;
+            SrcR.h = 64;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
+        //todo: mirroring
+        //case 4,6,7
+        case 129:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_HORIZONTAL;
+            break;
+        case 130:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_VERTICAL;
+            break;
+        case 131:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = (SDL_RendererFlip)(SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL);
+            break;
+        case 133:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 90;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 134:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 180;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 135:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 270;
+            flip = SDL_FLIP_NONE;
+            break;
+        default:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
     }
     
 

--- a/platform/SDL2Common/source/sdl2basehost.cpp
+++ b/platform/SDL2Common/source/sdl2basehost.cpp
@@ -298,7 +298,7 @@ void Host::waitForTargetFps(){
 }
 
 
-void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenMode){
+void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t drawMode){
     //clear screen to all black
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
@@ -321,7 +321,7 @@ void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenM
     SrcR.x = 0;
     SrcR.y = 0;
 
-    switch(screenMode){
+    switch(drawMode){
         case 1:
             SrcR.w = 64;
             SrcR.h = PicoScreenHeight;

--- a/platform/wiiu/source/WiiUHost.cpp
+++ b/platform/wiiu/source/WiiUHost.cpp
@@ -71,6 +71,9 @@ SDL_Event event;
 SDL_Renderer *renderer;
 SDL_Texture *texture = NULL;
 SDL_Rect DestR;
+SDL_Rect SrcR;
+double textureAngle;
+SDL_RendererFlip flip;
 SDL_AudioSpec want, have;
 SDL_AudioDeviceID dev;
 void *pixels;
@@ -84,10 +87,8 @@ SDL_Point touchLocation = { 128 / 2, 128 / 2 };
 void postFlipFunction(){
     //flush switch frame buffers
     // We're done rendering, so we end the frame here.
-    
-
     SDL_UnlockTexture(texture);
-    SDL_RenderCopy(renderer, texture, NULL, &DestR);
+    SDL_RenderCopyEx(renderer, texture, &SrcR, &DestR, textureAngle, NULL, flip);
 
     SDL_RenderPresent(renderer);
 }
@@ -156,6 +157,14 @@ void _changeStretch(StretchOption newStretch){
     DestR.y = WIN_HEIGHT / 2 - screenHeight / 2;
     DestR.w = screenWidth;
     DestR.h = screenHeight;
+
+    SrcR.x = 0;
+    SrcR.y = 0;
+    SrcR.w = PicoScreenWidth;
+    SrcR.h = PicoScreenHeight;
+
+    textureAngle = 0;
+    flip = SDL_FLIP_NONE;
 }
 
 Host::Host() {
@@ -400,7 +409,7 @@ void Host::waitForTargetFps(){
 }
 
 
-void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap){
+void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t drawMode){
     //clear screen to all black
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 0);
     SDL_RenderClear(renderer);
@@ -418,6 +427,75 @@ void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap){
             base[2] = col.Blue;
             base[3] = col.Alpha;
         }
+    }
+
+
+    SrcR.x = 0;
+    SrcR.y = 0;
+
+    switch(drawMode){
+        case 1:
+            SrcR.w = 64;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 2:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = 64;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 3:
+            SrcR.w = 64;
+            SrcR.h = 64;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
+        //todo: mirroring
+        //case 4,6,7
+        case 129:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_HORIZONTAL;
+            break;
+        case 130:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_VERTICAL;
+            break;
+        case 131:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = (SDL_RendererFlip)(SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL);
+            break;
+        case 133:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 90;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 134:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 180;
+            flip = SDL_FLIP_NONE;
+            break;
+        case 135:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 270;
+            flip = SDL_FLIP_NONE;
+            break;
+        default:
+            SrcR.w = PicoScreenWidth;
+            SrcR.h = PicoScreenHeight;
+            textureAngle = 0;
+            flip = SDL_FLIP_NONE;
+            break;
     }
     
 

--- a/source/host.h
+++ b/source/host.h
@@ -54,7 +54,7 @@ class Host {
     
     void waitForTargetFps();
 
-    void drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenMode);
+    void drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t drawMode);
 
     bool shouldFillAudioBuff();
     void* getAudioBufferPointer();

--- a/source/host.h
+++ b/source/host.h
@@ -54,7 +54,7 @@ class Host {
     
     void waitForTargetFps();
 
-    void drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap);
+    void drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenMode);
 
     bool shouldFillAudioBuff();
     void* getAudioBufferPointer();

--- a/source/p8GlobalLuaFunctions.h
+++ b/source/p8GlobalLuaFunctions.h
@@ -152,7 +152,7 @@ end
 
 
 __f08_menu_items = {
-    {"continue", __togglepausemenu},
+    [0] = {"continue", __togglepausemenu},
     {nil, nil},
     {nil, nil},
     {nil, nil},
@@ -162,7 +162,7 @@ __f08_menu_items = {
     {"exit to menu", __loadbioscart}
 }
 
-__f08_menu_selected = 1
+__f08_menu_selected = 0
 
 function __f08_menu_update()
     if btnp(3) and __f08_menu_selected < #__f08_menu_items then
@@ -181,6 +181,10 @@ function __f08_menu_update()
         toexec = __f08_menu_items[__f08_menu_selected]
         if toexec and toexec[2] then
             toexec[2]()
+            if __f08_menu_selected > 0 and __f08_menu_selected < 6 then
+                __f08_menu_selected = 0
+                __togglepausemenu()
+            end
         end
     end
 
@@ -189,7 +193,8 @@ end
 function __f08_menu_draw()
     local menuwidth = 82
     local itemcount = 0
-    for item in all(__f08_menu_items) do
+    for i=0, 7, 1 do
+        item = __f08_menu_items[i]
         if item[1] and item[2] then
             itemcount = itemcount + 1
         end
@@ -202,9 +207,10 @@ function __f08_menu_draw()
     rect(menux+1, menuy+1, menux + menuwidth-1, menuy + menuheight-1, 7)
     local itemx = menux + 8
     local itemy = menuy + 6
-    local itemidx = 1
+    local itemidx = 0
 
-    for item in all(__f08_menu_items) do
+    for i=0, 7, 1 do
+        item = __f08_menu_items[i]
         if item[1] and item[2] then
             print(item[1], itemx, itemy, 7)
             

--- a/source/vm.cpp
+++ b/source/vm.cpp
@@ -567,7 +567,7 @@ void Vm::GameLoop() {
 		uint8_t* picoFb = GetPicoInteralFb();
 		uint8_t* screenPaletteMap = GetScreenPaletteMap();
 
-		_host->drawFrame(picoFb, screenPaletteMap);
+		_host->drawFrame(picoFb, screenPaletteMap, _memory->drawState.drawMode);
 
 		if (_host->shouldFillAudioBuff()) {
 			FillAudioBuffer(_host->getAudioBufferPointer(), 0, _host->getAudioBufferSize());
@@ -866,7 +866,7 @@ void Vm::vm_flip() {
 		uint8_t* picoFb = GetPicoInteralFb();
 		uint8_t* screenPaletteMap = GetScreenPaletteMap();
 
-		_host->drawFrame(picoFb, screenPaletteMap);
+		_host->drawFrame(picoFb, screenPaletteMap, _memory->drawState.drawMode);
 
         //is this better at the end of the loop?
 		_host->waitForTargetFps();

--- a/test/stubhost.cpp
+++ b/test/stubhost.cpp
@@ -56,7 +56,7 @@ void Host::waitForTargetFps(){
 }
 
 
-void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap){
+void Host::drawFrame(uint8_t* picoFb, uint8_t* screenPaletteMap, uint8_t screenMode){
     
 }
 


### PR DESCRIPTION
All platforms:
* Implement stretched and flipped draw modes.
* Fix "continue" menu item being able to be overwritten
* Fix menu not dismissing when selecting a custom item

3ds Specific
* use citro2d for rendering instead of direct framebuffer access. Small performance improvement when using integer scaling, large improvement when not using integer scaling