### PR TITLE
Sound for Wii U and other minor fixes

### DIFF
--- a/platform/wiiu/source/WiiUHost.cpp
+++ b/platform/wiiu/source/WiiUHost.cpp
@@ -99,7 +99,7 @@ bool audioInitialized = false;
 void audioCleanup(){
     audioInitialized = false;
 
-    //SDL_CloseAudioDevice(dev);
+    SDL_CloseAudioDevice(dev);
 }
 
 void FillAudioDeviceBuffer(void* UserData, Uint8* DeviceBuffer, int Length)
@@ -111,7 +111,6 @@ void audioSetup(){
     //modifed from SDL docs: https://wiki.libsdl.org/SDL_OpenAudioDevice
 
     //Audio plays but is wrong. maybe a problem with sample rate or endian-ness? haven't investigated thoroughly
-/*
     SDL_memset(&want, 0, sizeof(want)); // or SDL_zero(want)
     want.freq = SAMPLERATE;
     want.format = AUDIO_S16SYS;
@@ -131,7 +130,6 @@ void audioSetup(){
 
         audioInitialized = true;
     }
-    */
 }
 
 

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -145,10 +145,10 @@ void Audio::set_music_pattern(int pattern) {
 
     //array to access song's channels. may be better to have this part of the struct?
     uint8_t channels[] = {
-        _memory->songs[pattern].sfx0,
-        _memory->songs[pattern].sfx1,
-        _memory->songs[pattern].sfx2,
-        _memory->songs[pattern].sfx3,
+        _memory->songs[pattern].getSfx0(),
+        _memory->songs[pattern].getSfx1(),
+        _memory->songs[pattern].getSfx2(),
+        _memory->songs[pattern].getSfx3(),
     };
 
     // Find music speed; it’s the speed of the fastest sfx
@@ -251,13 +251,13 @@ int16_t Audio::getSampleForChannel(int channel){
             int16_t next_pattern = _audioState._musicChannel.pattern + 1;
             int16_t next_count = _audioState._musicChannel.count + 1;
             //todo: pull out these flags, get memory storage correct as well
-            if (_memory->songs[_audioState._musicChannel.pattern].stop) //stop part of the loop flag
+            if (_memory->songs[_audioState._musicChannel.pattern].getStop()) //stop part of the loop flag
             {
                 next_pattern = -1;
                 next_count = _audioState._musicChannel.count;
             }
-            else if (_memory->songs[_audioState._musicChannel.pattern].loop){
-                while (--next_pattern > 0 && !_memory->songs[next_pattern].start)
+            else if (_memory->songs[_audioState._musicChannel.pattern].getLoop()){
+                while (--next_pattern > 0 && !_memory->songs[next_pattern].getStart())
                     ;
             }
 

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -296,8 +296,8 @@ int16_t Audio::getSampleForChannel(int channel){
     int const note_idx = (int)floor(offset);
     int const next_note_idx = (int)floor(next_offset);
 
-    uint8_t key = sfx.notes[note_idx].key;
-    float volume = sfx.notes[note_idx].volume / 7.f;
+    uint8_t key = sfx.notes[note_idx].getKey();
+    float volume = sfx.notes[note_idx].getVolume() / 7.f;
     float freq = key_to_freq(key);
 
     if (volume == 0.f){
@@ -308,8 +308,8 @@ int16_t Audio::getSampleForChannel(int channel){
             _audioState._sfxChannels[channel].sfxId = -1;
         }
         else if (next_note_idx != note_idx){
-            _audioState._sfxChannels[channel].prev_key = sfx.notes[note_idx].key;
-            _audioState._sfxChannels[channel].prev_vol = sfx.notes[note_idx].volume / 7.f;
+            _audioState._sfxChannels[channel].prev_key = sfx.notes[note_idx].getKey();
+            _audioState._sfxChannels[channel].prev_vol = sfx.notes[note_idx].getVolume() / 7.f;
         }
 
         return 0;
@@ -319,7 +319,7 @@ int16_t Audio::getSampleForChannel(int channel){
     //int const fx = sfx.notes[note_id].effect;
 
     // Play note
-    float waveform = z8::synth::waveform(sfx.notes[note_idx].waveform, phi);
+    float waveform = z8::synth::waveform(sfx.notes[note_idx].getWaveform(), phi);
 
     // Apply master music volume from fade in/out
     // FIXME: check whether this should be done after distortion
@@ -342,8 +342,8 @@ int16_t Audio::getSampleForChannel(int channel){
         _audioState._sfxChannels[channel].sfxId = -1;
     }
     else if (next_note_idx != note_idx){
-        _audioState._sfxChannels[channel].prev_key = sfx.notes[note_idx].key;
-        _audioState._sfxChannels[channel].prev_vol = sfx.notes[note_idx].volume / 7.f;
+        _audioState._sfxChannels[channel].prev_key = sfx.notes[note_idx].getKey();
+        _audioState._sfxChannels[channel].prev_vol = sfx.notes[note_idx].getVolume() / 7.f;
     }
 
     return sample;

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -199,8 +199,7 @@ void Audio::FillAudioBuffer(void *audioBuffer, size_t offset, size_t size){
         int16_t sample = 0;
 
         for (int c = 0; c < 4; ++c) {
-            //bit shifted 3 places to lower volume and avoid clipping
-            sample += this->getSampleForChannel(c) >> 3;
+            sample += this->getSampleForChannel(c);
         }
 
         //buffer is stereo, so just send the mono sample to both channels

--- a/source/PicoRam.h
+++ b/source/PicoRam.h
@@ -18,27 +18,40 @@
 0x6000 	0x7fff 	Screen data (8k) 
 */
 
-struct song {
-    union
-    {
-        struct
-        {
-            uint8_t sfx0  : 7;
-            uint8_t start : 1;
-            uint8_t sfx1  : 7;
-            uint8_t loop  : 1;
-            uint8_t sfx2  : 7;
-            uint8_t stop  : 1;
-            uint8_t sfx3  : 7;
-            uint8_t mode  : 1;
-        };
 
-        // The four song channels that should play, 0…63 (each msb holds a flag)
-        uint8_t data[4];
-    };
+//used to use a bitfield union for song and sfx. but this caused problems on big endian platforms
+//now use specific getter/setters that make sure bits are in the right spot
+struct song {
+    // The four song channels that should play, 0…63 (each msb holds a flag)
+    uint8_t data[4];
+
+    uint8_t getSfx0()const {
+        return (data[0] & 0b01111111);
+    }
+    uint8_t getSfx1()const {
+        return (data[1] & 0b01111111);
+    }
+    uint8_t getSfx2()const {
+        return (data[2] & 0b01111111);
+    }
+    uint8_t getSfx3()const {
+        return (data[3] & 0b01111111);
+    }
+
+    uint8_t getStart()const {
+        return (data[0] & 0b10000000) >> 7;
+    }
+    uint8_t getLoop()const {
+        return (data[1] & 0b10000000) >> 7;
+    }
+    uint8_t getStop()const {
+        return (data[2] & 0b10000000) >> 7;
+    }
+    uint8_t getMode()const {
+        return (data[3] & 0b10000000) >> 7;
+    }
 };
 
-//using uint16_t may be necessary since waveform spans two bytes
 struct note {
     uint8_t data[2];
 

--- a/source/PicoRam.h
+++ b/source/PicoRam.h
@@ -40,19 +40,52 @@ struct song {
 
 //using uint16_t may be necessary since waveform spans two bytes
 struct note {
-    union
-    {
-        struct
-        {
-            uint16_t key : 6;
-            uint16_t waveform : 3;
-            uint16_t volume : 3;
-            uint16_t effect : 3;
-            uint16_t custom : 1;
-        };
-        
-        uint8_t data[2];
-    };
+    uint8_t data[2];
+
+    void setKey(uint8_t val){
+        uint8_t mask = 0b00111111;
+        data[0] = (data[0] & ~mask) | (val & mask);
+    }
+    void setWaveform(uint8_t val){
+        //waveform spans both bytes
+        uint8_t val0 = val << 6;
+        uint8_t mask0 = 0b11000000;
+        data[0] = (data[0] & ~mask0) | (val0 & mask0);
+
+        uint8_t val1 = val >> 2;
+        uint8_t mask1 = 0b00000001;
+        data[1] = (data[1] & ~mask1) | (val1 & mask1);
+    }
+    void setVolume(uint8_t val){
+        uint8_t mask = 0b00001110;
+        data[1] = (data[1] & ~mask) | ((val << 1) & mask);
+    }
+    void setEffect(uint8_t val){
+        uint8_t mask = 0b01110000;
+        data[1] = (data[1] & ~mask) | ((val << 4) & mask);
+    }
+    void setCustom(uint8_t val){
+        uint8_t mask = 0b10000000;
+        data[1] = (data[1] & ~mask) | ((val << 7) & mask);
+    }
+
+
+    uint8_t getKey()const {
+        return (data[0] & 0b00111111);
+    }
+    uint8_t getWaveform()const {
+        //waveform spans both bytes
+        return ((data[1] & 0b00000001) << 2) + ((data[0] & 0b11000000) >> 6);
+    }
+    uint8_t getVolume()const {
+        return ((data[1] & 0b00001110) >> 1);
+    }
+    uint8_t getEffect()const {
+        return ((data[1] & 0b01110000) >> 4);
+    }
+    uint8_t getCustom()const {
+        return ((data[1] & 0b10000000) >> 7);
+    }
 };
 
 struct sfx {

--- a/source/cart.cpp
+++ b/source/cart.cpp
@@ -506,29 +506,29 @@ void Cart::setSfx(std::string sfxString) {
         for (int i = 8; i < 168; i+=5) {
             buf[0] = line[i];
             buf[1] = line[i + 1];
-            uint16_t key = (uint16_t)strtol(buf, NULL, 16);
+            uint8_t key = (uint8_t)strtol(buf, NULL, 16);
             
 
             buf[0] = '0';
             buf[1] = line[i + 2];
-            uint16_t waveform = (uint16_t)strtol(buf, NULL, 16);
-            uint16_t custom = waveform > 7 ? 1 : 0;
+            uint8_t waveform = (uint8_t)strtol(buf, NULL, 16);
+            uint8_t custom = waveform > 7 ? 1 : 0;
 
             buf[0] = '0';
             buf[1] = line[i + 3];
-            uint16_t volume = (uint16_t)strtol(buf, NULL, 16);
+            uint8_t volume = (uint8_t)strtol(buf, NULL, 16);
 
             buf[0] = '0';
             buf[1] = line[i + 4];
-            uint16_t effect = (uint16_t)strtol(buf, NULL, 16);
+            uint8_t effect = (uint8_t)strtol(buf, NULL, 16);
 
-            CartRom.SfxData[sfxIdx].notes[noteIdx++] = {
-                key,
-                waveform,
-                volume,
-                effect,
-                custom
-            };
+            CartRom.SfxData[sfxIdx].notes[noteIdx].setKey(key);
+            CartRom.SfxData[sfxIdx].notes[noteIdx].setWaveform(waveform);
+            CartRom.SfxData[sfxIdx].notes[noteIdx].setVolume(volume);
+            CartRom.SfxData[sfxIdx].notes[noteIdx].setEffect(effect);
+            CartRom.SfxData[sfxIdx].notes[noteIdx].setCustom(custom);
+
+            noteIdx++;
         }
 
         sfxIdx++;

--- a/source/logger.cpp
+++ b/source/logger.cpp
@@ -4,19 +4,24 @@
 
 #include "logger.h"
 
+#define LOGGER_ENABLED false
+
 FILE * m_file = nullptr;
 bool m_enabled = false;
 
 void Logger_Initialize(const char* pathPrefix)
 {
+    #if LOGGER_ENABLED
     std::string buf(pathPrefix);
     buf.append("pico.log");
     m_file = freopen(buf.c_str(), "w", stderr);
     m_enabled = true;
+    #endif
 }
 
 void Logger_LogOutput(const char * func, size_t line, const char * format, ...)
 {
+    #if LOGGER_ENABLED
     if (!m_enabled || !m_file)
         return;
 
@@ -28,10 +33,12 @@ void Logger_LogOutput(const char * func, size_t line, const char * format, ...)
     fprintf(m_file, "\n\n");
 
     fflush(m_file);
+    #endif
 }
 
 void Logger_Write(const char * format, ...)
 {
+    #if LOGGER_ENABLED
     if (!m_enabled || !m_file)
         return;
         
@@ -41,22 +48,27 @@ void Logger_Write(const char * format, ...)
     vfprintf(m_file, format, args);
 
     fflush(m_file);
+    #endif
 }
 
 void Logger_WriteUnformatted(const char * message)
 {
+    #if LOGGER_ENABLED
     if (!m_enabled || !m_file)
         return;
         
     fprintf(m_file, "%s", message);
 
     fflush(m_file);
+    #endif
 }
 
 void Logger_Exit()
 {
+    #if LOGGER_ENABLED
     if (!m_enabled || !m_file)
         return;
 
     fclose(m_file);
+    #endif
 }

--- a/source/vm.cpp
+++ b/source/vm.cpp
@@ -113,6 +113,11 @@ bool abortLua;
 
 bool Vm::loadCart(Cart* cart) {
     _picoFrameCount = 0;
+
+    if (_cartdataKey.length() > 0) {
+        _host->saveCartData(_cartdataKey, getSerializedCartData());
+    }
+
     _cartdataKey = "";
 
     //reset memory (may have to be more selective about zeroing out to be accurate?)
@@ -714,11 +719,6 @@ fix32 Vm::vm_dget(uint8_t n) {
 void Vm::vm_dset(uint8_t n, fix32 value){
     if (n < 64) {
         vm_poke4(0x5e00 + 4 * n, value);
-
-        //pico 8 seems to write immediately
-        if (_cartdataKey.length() > 0) {
-            _host->saveCartData(_cartdataKey, getSerializedCartData());
-        }
     }
 }
 

--- a/test/carttests.cpp
+++ b/test/carttests.cpp
@@ -86,12 +86,14 @@ TEST_CASE("Load simple p8 cart") {
         CHECK(cart->CartRom.SfxData[0].loopRangeEnd == 0);
         CHECK(cart->CartRom.SfxData[0].speed == 29);
 
-        CHECK(cart->CartRom.SfxData[0].notes[0].waveform == 0);
-        CHECK(cart->CartRom.SfxData[0].notes[0].effect == 0);
-        CHECK(cart->CartRom.SfxData[0].notes[0].key == 13);
-        CHECK(cart->CartRom.SfxData[0].notes[0].volume == 3);
         CHECK(cart->CartRom.SfxData[0].notes[0].data[0] == 13);
         CHECK(cart->CartRom.SfxData[0].notes[0].data[1] == 6);
+
+        CHECK(cart->CartRom.SfxData[0].notes[0].getWaveform() == 0);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getEffect() == 0);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getKey() == 13);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getVolume() == 3);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getCustom() == 0);
     }
     SUBCASE("Sfx data byte array is populated correctly") {
         CHECK(cart->CartRom.SfxData[2].data[0] == 139);
@@ -167,10 +169,10 @@ TEST_CASE("Load simple png cart") {
         CHECK(cart->CartRom.SfxData[0].loopRangeEnd == 0);
         CHECK(cart->CartRom.SfxData[0].speed == 29);
 
-        CHECK(cart->CartRom.SfxData[0].notes[0].waveform == 0);
-        CHECK(cart->CartRom.SfxData[0].notes[0].effect == 0);
-        CHECK(cart->CartRom.SfxData[0].notes[0].key == 13);
-        CHECK(cart->CartRom.SfxData[0].notes[0].volume == 3);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getWaveform() == 0);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getEffect() == 0);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getKey() == 13);
+        CHECK(cart->CartRom.SfxData[0].notes[0].getVolume() == 3);
         CHECK(cart->CartRom.SfxData[0].notes[0].data[0] == 13);
         CHECK(cart->CartRom.SfxData[0].notes[0].data[1] == 6);
     }

--- a/test/carttests.cpp
+++ b/test/carttests.cpp
@@ -117,14 +117,14 @@ TEST_CASE("Load simple p8 cart") {
         CHECK(cart->CartRom.SfxData[63].data[65] == 16);
     }
     SUBCASE("Music song data is populated") {
-        CHECK(cart->CartRom.SongData[0].sfx0 == 1);
-        CHECK(cart->CartRom.SongData[0].start == 0);
-        CHECK(cart->CartRom.SongData[0].sfx1 == 66);
-        CHECK(cart->CartRom.SongData[0].loop == 0);
-        CHECK(cart->CartRom.SongData[0].sfx2 == 67);
-        CHECK(cart->CartRom.SongData[0].stop == 0);
-        CHECK(cart->CartRom.SongData[0].sfx3 == 68);
-        CHECK(cart->CartRom.SongData[0].mode == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx0() == 1);
+        CHECK(cart->CartRom.SongData[0].getStart() == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx1() == 66);
+        CHECK(cart->CartRom.SongData[0].getLoop() == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx2() == 67);
+        CHECK(cart->CartRom.SongData[0].getStop() == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx3() == 68);
+        CHECK(cart->CartRom.SongData[0].getMode() == 0);
     }
     SUBCASE("Music data byte array is populated correctly") {
         CHECK(cart->CartRom.SongData[1].data[0] == 155);
@@ -177,14 +177,14 @@ TEST_CASE("Load simple png cart") {
         CHECK(cart->CartRom.SfxData[0].notes[0].data[1] == 6);
     }
     SUBCASE("Music data is populated") {
-        CHECK(cart->CartRom.SongData[0].sfx0 == 1);
-        CHECK(cart->CartRom.SongData[0].start == 0);
-        CHECK(cart->CartRom.SongData[0].sfx1 == 66);
-        CHECK(cart->CartRom.SongData[0].loop == 0);
-        CHECK(cart->CartRom.SongData[0].sfx2 == 67);
-        CHECK(cart->CartRom.SongData[0].stop == 0);
-        CHECK(cart->CartRom.SongData[0].sfx3 == 68);
-        CHECK(cart->CartRom.SongData[0].mode == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx0() == 1);
+        CHECK(cart->CartRom.SongData[0].getStart() == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx1() == 66);
+        CHECK(cart->CartRom.SongData[0].getLoop() == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx2() == 67);
+        CHECK(cart->CartRom.SongData[0].getStop() == 0);
+        CHECK(cart->CartRom.SongData[0].getSfx3() == 68);
+        CHECK(cart->CartRom.SongData[0].getMode() == 0);
     }
 
     delete cart;

--- a/test/vmtests.cpp
+++ b/test/vmtests.cpp
@@ -88,8 +88,8 @@ TEST_CASE("Vm memory functions") {
         //78: 0100 1110
         vm->vm_poke(0x3100, 78);
 
-        CHECK_EQ(memory->songs[0].sfx0, 78);
-        CHECK_EQ(memory->songs[0].start, 0);
+        CHECK_EQ(memory->songs[0].getSfx0(), 78);
+        CHECK_EQ(memory->songs[0].getStart(), 0);
     }
     SUBCASE("poking sfx"){
         //97: 0110 0001
@@ -352,14 +352,14 @@ TEST_CASE("Vm memory functions") {
             CHECK(memory->sfx[0].notes[0].data[1] == 6);
         }
         SUBCASE("Music data is populated") {
-            CHECK(memory->songs[0].sfx0 == 1);
-            CHECK(memory->songs[0].start == 0);
-            CHECK(memory->songs[0].sfx1 == 66);
-            CHECK(memory->songs[0].loop == 0);
-            CHECK(memory->songs[0].sfx2 == 67);
-            CHECK(memory->songs[0].stop == 0);
-            CHECK(memory->songs[0].sfx3 == 68);
-            CHECK(memory->songs[0].mode == 0);
+            CHECK(memory->songs[0].getSfx0() == 1);
+            CHECK(memory->songs[0].getStart() == 0);
+            CHECK(memory->songs[0].getSfx1() == 66);
+            CHECK(memory->songs[0].getLoop() == 0);
+            CHECK(memory->songs[0].getSfx2() == 67);
+            CHECK(memory->songs[0].getStop() == 0);
+            CHECK(memory->songs[0].getSfx3() == 68);
+            CHECK(memory->songs[0].getMode() == 0);
         }
     }
     SUBCASE("reload writes cart rom over changes") {

--- a/test/vmtests.cpp
+++ b/test/vmtests.cpp
@@ -97,8 +97,8 @@ TEST_CASE("Vm memory functions") {
         //waveform is next 3: (0) 01 : 1
         vm->vm_poke(0x3200, 97);
 
-        CHECK_EQ(memory->sfx[0].notes[0].key, 33);
-        CHECK_EQ(memory->sfx[0].notes[0].waveform, 1);
+        CHECK_EQ(memory->sfx[0].notes[0].getKey(), 33);
+        CHECK_EQ(memory->sfx[0].notes[0].getWaveform(), 1);
     }
     SUBCASE("poking general use ram"){
         vm->vm_poke(0x4300, 215);
@@ -344,10 +344,10 @@ TEST_CASE("Vm memory functions") {
             CHECK(memory->sfx[0].loopRangeEnd == 0);
             CHECK(memory->sfx[0].speed == 29);
 
-            CHECK(memory->sfx[0].notes[0].waveform == 0);
-            CHECK(memory->sfx[0].notes[0].effect == 0);
-            CHECK(memory->sfx[0].notes[0].key == 13);
-            CHECK(memory->sfx[0].notes[0].volume == 3);
+            CHECK(memory->sfx[0].notes[0].getWaveform() == 0);
+            CHECK(memory->sfx[0].notes[0].getEffect() == 0);
+            CHECK(memory->sfx[0].notes[0].getKey() == 13);
+            CHECK(memory->sfx[0].notes[0].getVolume() == 3);
             CHECK(memory->sfx[0].notes[0].data[0] == 13);
             CHECK(memory->sfx[0].notes[0].data[1] == 6);
         }
@@ -600,6 +600,26 @@ TEST_CASE("Vm memory functions") {
             "0000000000000000000000000000000000000000000000000000000000000000\n";
 
         CHECK_EQ(expected, actual);
+    }
+    SUBCASE("SFX Note getters match expected values"){
+        memory->sfx[0].notes[0].data[0] = 205;
+        memory->sfx[0].notes[0].data[1] = 233;
+
+        CHECK(memory->sfx[0].notes[0].getWaveform() == 7);
+        CHECK(memory->sfx[0].notes[0].getEffect() == 6);
+        CHECK(memory->sfx[0].notes[0].getKey() == 13);
+        CHECK(memory->sfx[0].notes[0].getVolume() == 4);
+        CHECK(memory->sfx[0].notes[0].getCustom() == 1);
+    }
+    SUBCASE("SFX Note settiers set correct values"){
+        memory->sfx[0].notes[0].setWaveform(7);
+        memory->sfx[0].notes[0].setEffect(6);
+        memory->sfx[0].notes[0].setKey(13);
+        memory->sfx[0].notes[0].setVolume(4);
+        memory->sfx[0].notes[0].setCustom(1);
+
+        CHECK(memory->sfx[0].notes[0].data[0] == 205);
+        CHECK(memory->sfx[0].notes[0].data[1] == 233);
     }
 
     delete stubHost;


### PR DESCRIPTION
- Refactor song and note structs to not use bitfields, but manually read/write the correct bits from the data byte arrays. This fixes audio on the Wii U (and potential future Big Endian platforms)
- Increase audio volume by removing bit shifting that was intended to reduce clipping, but doesn't appear to be helping
- Turn off logger by default (stop unnecessary disc I/O)
- Only write cartdata file on cart closure to avoid pauses mid game