### PR TITLE
Suppress pause bug fixes

### DIFF
--- a/platform/SDL2Desktop/source/SDL2Host.cpp
+++ b/platform/SDL2Desktop/source/SDL2Host.cpp
@@ -80,7 +80,7 @@ Host::Host()
 
 InputState_t Host::scanInput(){
     currKDown = 0;
-    currKHeld = 0;
+    uint8_t kUp = 0;
     stretchKeyPressed = false;
 
     currKBDown = false;
@@ -127,6 +127,21 @@ InputState_t Host::scanInput(){
                     case SDLK_r:     stretchKeyPressed = true; break;
                 }
                 break;
+            
+            case SDL_KEYUP:
+                switch (event.key.keysym.sym)
+                {
+                    case SDLK_ESCAPE:case SDLK_RETURN:case SDLK_RETURN2:
+                                     kUp |= P8_KEY_PAUSE; break;
+                    case SDLK_LEFT:  kUp |= P8_KEY_LEFT; break;
+                    case SDLK_RIGHT: kUp |= P8_KEY_RIGHT; break;
+                    case SDLK_UP:    kUp |= P8_KEY_UP; break;
+                    case SDLK_DOWN:  kUp |= P8_KEY_DOWN; break;
+                    case SDLK_z:     kUp |= P8_KEY_X; break;
+                    case SDLK_x:     kUp |= P8_KEY_O; break;
+                    case SDLK_c:     kUp |= P8_KEY_X; break;
+                }
+                break;
 
             case SDL_QUIT:
                 quit = 1;
@@ -153,39 +168,8 @@ InputState_t Host::scanInput(){
         picoMouseState |= 2;
     }
 
-    const Uint8* keystate = SDL_GetKeyboardState(NULL);
-
-    //continuous-response keys
-    if(keystate[SDL_SCANCODE_ESCAPE]){
-        currKHeld |= P8_KEY_PAUSE;
-    }
-    if(keystate[SDL_SCANCODE_RETURN]){
-        currKHeld |= P8_KEY_PAUSE;
-    }
-    if(keystate[SDL_SCANCODE_RETURN2]){
-        currKHeld |= P8_KEY_PAUSE;
-    }
-    if(keystate[SDL_SCANCODE_LEFT]){
-        currKHeld |= P8_KEY_LEFT;
-    }
-    if(keystate[SDL_SCANCODE_RIGHT]){
-        currKHeld |= P8_KEY_RIGHT;;
-    }
-    if(keystate[SDL_SCANCODE_UP]){
-        currKHeld |= P8_KEY_UP;
-    }
-    if(keystate[SDL_SCANCODE_DOWN]){
-        currKHeld |= P8_KEY_DOWN;
-    }
-    if(keystate[SDL_SCANCODE_Z]){
-        currKHeld |= P8_KEY_X;
-    }
-    if(keystate[SDL_SCANCODE_X]){
-        currKHeld |= P8_KEY_O;
-    }
-    if(keystate[SDL_SCANCODE_C]){
-        currKHeld |= P8_KEY_X;
-    }
+    currKHeld |= currKDown;
+    currKHeld ^= kUp;
     
     return InputState_t {
         currKDown,

--- a/source/Input.h
+++ b/source/Input.h
@@ -6,6 +6,7 @@
 class Input{
     PicoRam* _memory;
 	uint8_t _currentKDown;
+    uint8_t _currentKHeld;
 
 	uint16_t _framesHeld[8];
 

--- a/source/picoluaapi.cpp
+++ b/source/picoluaapi.cpp
@@ -864,6 +864,16 @@ int stat(lua_State *L) {
             lua_pushnumber(L, _audioForLuaApi->getMusicTickCount());
             return 1;
         break;
+        //if SDL scancode is pressed. always false for now
+        case 28:
+            lua_pushboolean(L, false);
+            return 1;
+        break;
+        //unknown. appears to always be 0
+        case 29:
+            lua_pushnumber(L, 0);
+            return 1;
+        break;
         //was a key pressed 
         case 30:
             lua_pushboolean(L, _inputForLuaApi->getKeyDown());			

--- a/source/vm.cpp
+++ b/source/vm.cpp
@@ -423,7 +423,8 @@ void Vm::LoadCart(std::string filename){
 }
 
 void Vm::togglePauseMenu(){
-    if (_memory->drawState.suppressPause) {
+    _input->SetState(0, 0);
+    if (_memory->drawState.suppressPause) {    
         _memory->drawState.suppressPause = 0;
         return;
     }
@@ -512,10 +513,6 @@ void Vm::UpdateAndDraw() {
 
     _picoFrameCount++;
 
-    if (_input->btnp(6)) {
-        togglePauseMenu();
-    }
-
     if (_cartChangeQueued) {
         _prevCartKey = CurrentCartFilename();
         LoadCart(_nextCartKey);
@@ -568,6 +565,10 @@ void Vm::UpdateAndDraw() {
             }
         }
         lua_pop(_luaState, 0);
+
+        if (_input->btnp(6)) {
+            togglePauseMenu();
+        }
     }
 
 }

--- a/test/vmtests.cpp
+++ b/test/vmtests.cpp
@@ -271,16 +271,12 @@ TEST_CASE("Vm memory functions") {
 
         CHECK_EQ(memory->hwState.rngState[0], 20);
     }
-    SUBCASE("poking button state") {
+    SUBCASE("poking button state doesn't affect input") {
         //0000 1010
         vm->vm_poke(0x5f4c, 10);
 
         CHECK_EQ(memory->hwState.buttonStates[0], 10);
-        CHECK_EQ(input->btn(), 10);
-        CHECK_EQ(input->btn(0), false);
-        CHECK_EQ(input->btn(1), true);
-        CHECK_EQ(input->btn(2), false);
-        CHECK_EQ(input->btn(3), true);
+        CHECK_EQ(input->btn(), 0);
     }
     SUBCASE("poking print attributes") {
         vm->vm_poke(0x5f58, 53);


### PR DESCRIPTION
Improve handling of the memory location to supress the pause menu. Also stub out stat 28 and 29. These two things combined should fix weapon switching in Poom.
