### PR TITLE
Sprite sheet overflow wrapping

### DIFF
--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -302,7 +302,7 @@ void Graphics::copyStretchSpriteToScreen(
 	if (hwState.colorBitmask == 0xff){
 		for (int y = 0; y < scr_h; y++) {
 			int sprY = ((spr_y + y * dy) >> 16);
-			if (sprY > 63) {
+			if (sprY > 127) {
 				continue;
 			}
 			uint8_t* spr = spritebuffer + (sprY * 64);
@@ -362,7 +362,7 @@ void Graphics::copyStretchSpriteToScreen(
 	else {
 		for (int y = 0; y < scr_h; y++) {
 			int sprY = ((spr_y + y * dy) >> 16);
-			if (sprY > 63) {
+			if (sprY > 127) {
 				continue;
 			}
 			uint8_t* spr = spritebuffer + (sprY) * 64;

--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -1515,10 +1515,12 @@ uint8_t Graphics::mget(int celx, int cely){
 
 	const int mapW = _memory->hwState.widthOfTheMap == 0 ? 256 : _memory->hwState.widthOfTheMap;
 	const int mapH = mapSize / mapW;
+	const int maxXIdx = mapW - 1;
+	const int maxYIdx = mapH - 1;
 
 	const int idx = cely * mapW + celx;
 
-	if (celx < 0 || celx > mapW || cely < 0 || cely > mapH) {
+	if (celx < 0 || celx > maxXIdx || cely < 0 || cely > maxYIdx) {
         return 0;
 	}
 	

--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -1457,11 +1457,17 @@ void Graphics::fset(uint8_t n, uint8_t v){
 }
 
 uint8_t Graphics::sget(uint8_t x, uint8_t y){
-	return getPixelNibble(x, y, GetP8SpriteSheetBuffer());
+	if (IS_VALID_SPR_IDX(x, y)) {
+		return getPixelNibble(x, y, GetP8SpriteSheetBuffer());
+	}
+	return 0;
 }
 
 void Graphics::sset(uint8_t x, uint8_t y, uint8_t c){
-	setPixelNibble(x, y, c, GetP8SpriteSheetBuffer());
+	if (IS_VALID_SPR_IDX(x, y)) {
+		setPixelNibble(x, y, c, GetP8SpriteSheetBuffer());
+	}
+	return;
 }
 
 std::tuple<int16_t, int16_t> Graphics::camera() {

--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -126,6 +126,10 @@ void Graphics::copySpriteToScreen(
 		while (x < scr_w) {
 			int abs_spr_x = spr_x + (flip_x ? spr_w - (x + 1) : x);
 			int abs_spr_y = spr_y + (flip_y ? spr_h - (y + 1) : y);
+			if (!IS_VALID_SPR_IDX(abs_spr_x, abs_spr_y)){
+				++x;
+				continue;
+			}
 			uint8_t bothPix = spritebuffer[COMBINED_IDX(abs_spr_x, abs_spr_y)];
 
 			//uint8_t c = (BITMASK(0) & abs_spr_x)== 0 
@@ -298,21 +302,28 @@ void Graphics::copyStretchSpriteToScreen(
 	if (hwState.colorBitmask == 0xff){
 		for (int y = 0; y < scr_h; y++) {
 			int sprY = ((spr_y + y * dy) >> 16);
-			uint8_t* spr = spritebuffer + (sprY & 0x7f) * 64;
+			if (sprY > 63) {
+				continue;
+			}
+			uint8_t* spr = spritebuffer + (sprY * 64);
 
 			if (skipStretchPx && prevSprY == sprY){
 				continue;
 			}
+			
 			prevSprY = sprY;
 
 			if (!flip_x) {
 				for (int x = 0; x < scr_w; x++) {
 					int shiftedPixIndex = (spr_x + x * dx) >> 16;
+					if (shiftedPixIndex > 127) {
+						continue;
+					}
 					if (skipStretchPx && prevSprX == shiftedPixIndex){
 						continue;
 					}
 					prevSprX = shiftedPixIndex;
-					int preShiftedCombinedPixIndex = (shiftedPixIndex / 2) & 0x7f;
+					int preShiftedCombinedPixIndex = (shiftedPixIndex / 2);
 					uint8_t bothPix = spr[preShiftedCombinedPixIndex];
 
 					uint8_t c = shiftedPixIndex % 2 == 0 
@@ -328,7 +339,11 @@ void Graphics::copyStretchSpriteToScreen(
 			} else {
 				for (int x = 0; x < scr_w; x++) {
 					int pixIndex = (spr_x + spr_w - (x + 1) * dx);
-					int combinedPixIdx = ((pixIndex / 2) >> 16) & 0x7f;
+					int shiftedPixIndex = pixIndex >> 16;
+					if (shiftedPixIndex > 127) {
+						continue;
+					}
+					int combinedPixIdx = shiftedPixIndex / 2;
 					uint8_t bothPix = spr[combinedPixIdx];
 
 					uint8_t c = (pixIndex >> 16) % 2 == 0 
@@ -346,15 +361,22 @@ void Graphics::copyStretchSpriteToScreen(
 	}
 	else {
 		for (int y = 0; y < scr_h; y++) {
-			uint8_t* spr = spritebuffer + (((spr_y + y * dy) >> 16) & 0x7f) * 64;
+			int sprY = ((spr_y + y * dy) >> 16);
+			if (sprY > 63) {
+				continue;
+			}
+			uint8_t* spr = spritebuffer + (sprY) * 64;
 
 			if (!flip_x) {
 				for (int x = 0; x < scr_w; x++) {
-					int pixIndex = (spr_x + x * dx);
-					int combinedPixIdx = ((pixIndex / 2) >> 16) & 0x7f;
+					int shiftedPixIndex = (spr_x + x * dx) >> 16;
+					if (shiftedPixIndex > 127) {
+						continue;
+					}
+					int combinedPixIdx = (shiftedPixIndex / 2);
 					uint8_t bothPix = spr[combinedPixIdx];
 
-					uint8_t c = (pixIndex >> 16) % 2 == 0 
+					uint8_t c = shiftedPixIndex % 2 == 0 
 						? bothPix & 0x0f //just first 4 bits
 						: bothPix >> 4;  //just last 4 bits
 
@@ -377,7 +399,11 @@ void Graphics::copyStretchSpriteToScreen(
 			} else {
 				for (int x = 0; x < scr_w; x++) {
 					int pixIndex = (spr_x + spr_w - (x + 1) * dx);
-					int combinedPixIdx = ((pixIndex / 2) >> 16) & 0x7f;
+					int shiftedPixIndex = pixIndex >> 16;
+					if (shiftedPixIndex > 127) {
+						continue;
+					}
+					int combinedPixIdx = (shiftedPixIndex / 2);
 					uint8_t bothPix = spr[combinedPixIdx];
 
 					uint8_t c = (pixIndex >> 16) % 2 == 0 

--- a/source/nibblehelpers.cpp
+++ b/source/nibblehelpers.cpp
@@ -12,6 +12,11 @@ int getCombinedIdx(const int x, const int y){
 	//return (y << 6) | (x >> 1);
 	return COMBINED_IDX(x, y);
 }
+
+int isValidSprIdx(int x, int y){
+	return IS_VALID_SPR_IDX(x, y);
+}
+
 //try look up table to optimize?
 
 void setPixelNibble(const int x, const int y, uint8_t value, uint8_t* targetBuffer) {

--- a/source/nibblehelpers.h
+++ b/source/nibblehelpers.h
@@ -5,6 +5,7 @@
 //for 1 byte (8 bit) indexes, 128x64
 //should be the equivalent of return y * 64 + (x / 2);
 #define COMBINED_IDX(x, y) ((y) << 6) | ((x) >> 1)
+#define IS_VALID_SPR_IDX(x, y) (y >= 0 && y < 64 && x >= 0 && x < 128)
 //I think this should work if you cast the buffer to a uint32_t* pointer, but not tested
 //for 4 byte (32 bit) inexes, 16x8
 //should be the equivalent of return y * 16 + (x / 8);
@@ -14,6 +15,8 @@
 //split it up by bit shifting, and write to screen buffer as necessary
 
 int getCombinedIdx(int x, int y);
+
+int isValidSprIdx(int x, int y);
 
 void setPixelNibble(const int x, const int y, uint8_t value, uint8_t* targetBuffer);
 

--- a/source/nibblehelpers.h
+++ b/source/nibblehelpers.h
@@ -5,7 +5,7 @@
 //for 1 byte (8 bit) indexes, 128x64
 //should be the equivalent of return y * 64 + (x / 2);
 #define COMBINED_IDX(x, y) ((y) << 6) | ((x) >> 1)
-#define IS_VALID_SPR_IDX(x, y) (y >= 0 && y < 64 && x >= 0 && x < 128)
+#define IS_VALID_SPR_IDX(x, y) (y >= 0 && y < 128 && x >= 0 && x < 128)
 //I think this should work if you cast the buffer to a uint32_t* pointer, but not tested
 //for 4 byte (32 bit) inexes, 16x8
 //should be the equivalent of return y * 16 + (x / 8);

--- a/test/cartloadingtest.cpp
+++ b/test/cartloadingtest.cpp
@@ -582,7 +582,8 @@ TEST_CASE("Loading and running carts") {
 
 
     //TODO: build library of carts to test- set up compiler flag?
-    std::string _cartDirectory = "/Users/jon/p8carts/archive/carts";
+    //std::string _cartDirectory = "/Users/jon/p8carts/archive/carts";
+    std::string _cartDirectory = "";
 
     DIR *dir;
     struct dirent *ent;

--- a/test/graphicstests.cpp
+++ b/test/graphicstests.cpp
@@ -769,6 +769,28 @@ TEST_CASE("graphics class behaves as expected") {
 
         checkPoints(graphics, expectedPoints);
     }
+    SUBCASE("spr(...) draws doesn't repeat sprites if spritesheet width is exceeded") {
+        graphics->cls();
+        for(int y = 0; y < 128; y++) {
+            for(int x = 0; x < 128; x++) {
+                graphics->sset(x, y, (x+y)%15+1);
+            }
+        }
+
+        //sprite 6, but a width and height of 16 pixels goes off the edge.
+        //it should end instead of wrapping
+        graphics->spr(6, 0, 40, 16, 16, false, false);
+        
+        std::vector<coloredPoint> expectedPoints = {
+            {81, 40, 0},
+            {81, 41, 0},
+            {81, 42, 0},
+            {81, 43, 0},
+            {81, 44, 0},
+        };
+
+        checkPoints(graphics, expectedPoints);
+    }
     SUBCASE("sspr(...) draws to screen at odd numbered location") {
         graphics->cls();
         
@@ -920,6 +942,29 @@ TEST_CASE("graphics class behaves as expected") {
             {102, 47, 5},
             {102, 48, 5},
             {102, 49, 5},
+        };
+
+        checkPoints(graphics, expectedPoints);
+    }
+    SUBCASE("sspr(...) draws doesn't repeat sprites if spritesheet width is exceeded") {
+        graphics->cls();
+        for(int y = 0; y < 128; y++) {
+            for(int x = 0; x < 128; x++) {
+                graphics->sset(x, y, (x+y)%15+1);
+            }
+        }
+
+        //sprite 6, but a width and height of 16 pixels goes off the edge.
+        //it should end instead of wrapping
+        graphics->sspr(48, 0, 128, 32, 100, 50, 3, -4, false, false);
+        graphics->spr(6, 0, 40, 16, 16, false, false);
+        
+        std::vector<coloredPoint> expectedPoints = {
+            {81, 40, 0},
+            {81, 41, 0},
+            {81, 42, 0},
+            {81, 43, 0},
+            {81, 44, 0},
         };
 
         checkPoints(graphics, expectedPoints);

--- a/test/graphicstests.cpp
+++ b/test/graphicstests.cpp
@@ -933,7 +933,6 @@ TEST_CASE("graphics class behaves as expected") {
             {102, 51, 5},
             {102, 52, 5},
             {102, 53, 5},
-            
         };
 
         checkPoints(graphics, expectedPoints);
@@ -985,6 +984,33 @@ TEST_CASE("graphics class behaves as expected") {
             {81, 42, 0},
             {81, 43, 0},
             {81, 44, 0},
+        };
+
+        checkPoints(graphics, expectedPoints);
+    }
+    SUBCASE("sspr(...) draws last sprite (sprite 255)") {
+        graphics->cls();
+        for(int y = 0; y < 128; y++) {
+            for(int x = 0; x < 128; x++) {
+                graphics->sset(x, y, (x+y)%15+1);
+            }
+        }
+
+        graphics->sspr(120, 120, 3, 4, 100, 50, 6, 8, false, false);
+
+        std::vector<coloredPoint> expectedPoints = {
+            {100, 50, 1},
+            {100, 51, 1},
+            {100, 52, 2},
+            {100, 53, 2},
+            {101, 50, 1},
+            {101, 51, 1},
+            {101, 52, 2},
+            {101, 53, 2},
+            {102, 50, 2},
+            {102, 51, 2},
+            {102, 52, 3},
+            {102, 53, 3},
         };
 
         checkPoints(graphics, expectedPoints);

--- a/test/graphicstests.cpp
+++ b/test/graphicstests.cpp
@@ -791,6 +791,26 @@ TEST_CASE("graphics class behaves as expected") {
 
         checkPoints(graphics, expectedPoints);
     }
+    SUBCASE("spr(...) draws last sprite (sprite 255)") {
+        graphics->cls();
+        for(int y = 0; y < 128; y++) {
+            for(int x = 0; x < 128; x++) {
+                graphics->sset(x, y, (x+y)%15+1);
+            }
+        }
+
+        graphics->spr(255, 0, 120, 1, 1, false, false);
+        
+        std::vector<coloredPoint> expectedPoints = {
+            {0, 120, 1}, 
+            {0, 121, 2},
+            {0, 122, 3},
+            {0, 123, 4},
+            {0, 124, 5},
+        };
+
+        checkPoints(graphics, expectedPoints);
+    }
     SUBCASE("sspr(...) draws to screen at odd numbered location") {
         graphics->cls();
         
@@ -1073,6 +1093,18 @@ TEST_CASE("graphics class behaves as expected") {
 
        CHECK_EQ(result, 12);
    }
+   SUBCASE("sget returns 0 when out of bounds") {
+        graphics->cls();
+        for(int y = 0; y < 128; y++) {
+            for(int x = 0; x < 128; x++) {
+                graphics->sset(x, y, (x+y)%15+1);
+            }
+        }
+
+        auto result = graphics->sget(128, 128);
+
+       CHECK_EQ(result, 0);
+    }
    SUBCASE("sset sets value in ram for even x pixel")
    {
        uint8_t x = 60;
@@ -1094,6 +1126,17 @@ TEST_CASE("graphics class behaves as expected") {
        auto result = picoRam.spriteSheetData[combinedIdx];
 
        CHECK_EQ(result, 192);
+   }
+   SUBCASE("sset does nothing for out of bounds pixel")
+   {
+       uint8_t x = 128;
+       uint8_t y = 0;
+       graphics->sset(x, y, 14); //14 = 1110
+
+       int combinedIdx = y * 64 + (x / 2);
+       auto result = picoRam.spriteSheetData[combinedIdx];
+
+       CHECK_EQ(result, 0);
    }
    SUBCASE("camera({x}, {y}) sets values in memory")
    {

--- a/test/graphicstests.cpp
+++ b/test/graphicstests.cpp
@@ -1574,9 +1574,9 @@ TEST_CASE("graphics class behaves as expected") {
             }
         }
         auto result1 = graphics->mget(-1, 16);
-        auto result2 = graphics->mget(129, 16);
+        auto result2 = graphics->mget(128, 16);
         auto result3 = graphics->mget(10, -1);
-        auto result4 = graphics->mget(10, 67);
+        auto result4 = graphics->mget(10, 64);
 
         CHECK_EQ(0, result1);
         CHECK_EQ(0, result2);

--- a/test/nibblehelperstests.cpp
+++ b/test/nibblehelperstests.cpp
@@ -2,19 +2,37 @@
 #include "../source/nibblehelpers.h"
 
 TEST_CASE("Get Combined pixel index") {
-    SUBCASE("0,0") {
+    SUBCASE("getCombinedIdx 0,0") {
         CHECK_EQ(getCombinedIdx(0, 0), 0);
     }
-    SUBCASE("1,0") {
+    SUBCASE("getCombinedIdx 1,0") {
         CHECK_EQ(getCombinedIdx(1, 0), 0);
     }
-    SUBCASE("127, 127") {
+    SUBCASE("getCombinedIdx 127, 127") {
         CHECK_EQ(getCombinedIdx(127, 127), 8191);
     }
-    SUBCASE("126, 127") {
+    SUBCASE("getCombinedIdx 126, 127") {
         CHECK_EQ(getCombinedIdx(127, 127), 8191);
     }
-    SUBCASE("37, 99") {
+    SUBCASE("getCombinedIdx 37, 99") {
         CHECK_EQ(getCombinedIdx(37, 99), 6354);
+    }
+    SUBCASE("isValidSprIdx 0,0 true") {
+        CHECK(isValidSprIdx(0, 0));
+    }
+    SUBCASE("isValidSprIdx 1,0 true") {
+        CHECK(isValidSprIdx(1, 0));
+    }
+    SUBCASE("isValidSprIdx 127, 127 true") {
+        CHECK(isValidSprIdx(127, 63));
+    }
+    SUBCASE("isValidSprIdx -1,0 false") {
+        CHECK_FALSE(isValidSprIdx(-1, 0));
+    }
+    SUBCASE("isValidSprIdx 128, 127 false") {
+        CHECK_FALSE(isValidSprIdx(128, 63));
+    }
+    SUBCASE("isValidSprIdx 127, 64 false") {
+        CHECK_FALSE(isValidSprIdx(127, 64));
     }
 }

--- a/test/nibblehelperstests.cpp
+++ b/test/nibblehelperstests.cpp
@@ -24,15 +24,15 @@ TEST_CASE("Get Combined pixel index") {
         CHECK(isValidSprIdx(1, 0));
     }
     SUBCASE("isValidSprIdx 127, 127 true") {
-        CHECK(isValidSprIdx(127, 63));
+        CHECK(isValidSprIdx(127, 127));
     }
     SUBCASE("isValidSprIdx -1,0 false") {
         CHECK_FALSE(isValidSprIdx(-1, 0));
     }
     SUBCASE("isValidSprIdx 128, 127 false") {
-        CHECK_FALSE(isValidSprIdx(128, 63));
+        CHECK_FALSE(isValidSprIdx(128, 127));
     }
-    SUBCASE("isValidSprIdx 127, 64 false") {
-        CHECK_FALSE(isValidSprIdx(127, 64));
+    SUBCASE("isValidSprIdx 127, 128 false") {
+        CHECK_FALSE(isValidSprIdx(127, 128));
     }
 }


### PR DESCRIPTION
Fix some bugs drawing sprites. 

Fix issue when drawing past the right edge of the sprite sheet with spr and sspr (sprite sheet x dimensions > 127 used to wrap to the next line. They now correctly draw nothing)
Fix  mget off by one error to not wrap to first sprite of the next line

