### PR TITLE
Fix songs with looping sections being cut short.

### DIFF
--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -165,12 +165,12 @@ void Audio::set_music_pattern(int pattern) {
         if (n & 0x40)
             continue;
 	// we ignore loooping length if we have non-looping channel
+        auto &sfx = _memory->sfx[n & 0x3f];
         bool looping = sfx.loopRangeStart < sfx.loopRangeEnd;
 	bool firstNonLooping = !looping && !foundNonLooping;
 	if (!looping) {
 		foundNonLooping=true;
 	}
-        auto &sfx = _memory->sfx[n & 0x3f];
         if ((!looping || !foundNonLooping) && firstNonLooping || (_audioState._musicChannel.master == -1 || _audioState._musicChannel.speed > sfx.speed))
         {
             _audioState._musicChannel.master = i;

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -171,7 +171,7 @@ void Audio::set_music_pattern(int pattern) {
             _audioState._musicChannel.speed = std::max(1, (int)sfx.speed);
         }
 		
-		if(sfx.loopRangeStart != 0 && sfx.loopRangeEnd == 0){
+		if(sfx.loopRangeStart >= sfx.loopRangeEnd){
 			_audioState._musicChannel.length = std::min(_audioState._musicChannel.length, sfx.loopRangeStart);			
 		}
 		

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -154,7 +154,6 @@ void Audio::set_music_pattern(int pattern) {
     };
 
     bool foundNonLooping = false;
-    bool foundLooping = false;
     // Find music speed; it’s the speed of the fastest sfx
 	// While we are looping through this, find the lowest *valid* sfx length
     _audioState._musicChannel.master = _audioState._musicChannel.speed = -1;
@@ -169,9 +168,6 @@ void Audio::set_music_pattern(int pattern) {
         auto &sfx = _memory->sfx[n & 0x3f];
         bool looping = sfx.loopRangeStart < sfx.loopRangeEnd;
 	bool firstNonLooping = !looping && !foundNonLooping;
-	if (looping) {
-		foundLooping=true;
-	}
 	if (!looping) {
 		foundNonLooping=true;
 	}
@@ -204,7 +200,8 @@ void Audio::set_music_pattern(int pattern) {
         _audioState._sfxChannels[i].sfxId = n;
         _audioState._sfxChannels[i].offset = 0.f;
         _audioState._sfxChannels[i].phi = 0.f;
-        _audioState._sfxChannels[i].can_loop = foundLooping && foundNonLooping;
+	// if the master channel loops we'll never finish
+        _audioState._sfxChannels[i].can_loop = i != _audioState._musicChannel.master;
         _audioState._sfxChannels[i].is_music = true;
         _audioState._sfxChannels[i].prev_key = 24;
         _audioState._sfxChannels[i].prev_vol = 0.f;

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -171,7 +171,7 @@ void Audio::set_music_pattern(int pattern) {
 	if (!looping) {
 		foundNonLooping=true;
 	}
-        if ((!looping || !foundNonLooping) && firstNonLooping || (_audioState._musicChannel.master == -1 || _audioState._musicChannel.speed > sfx.speed))
+        if ((!looping || !foundNonLooping) && (firstNonLooping || _audioState._musicChannel.master == -1 || _audioState._musicChannel.speed > sfx.speed))
         {
             _audioState._musicChannel.master = i;
             _audioState._musicChannel.speed = std::max(1, (int)sfx.speed);

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -154,6 +154,7 @@ void Audio::set_music_pattern(int pattern) {
     };
 
     bool foundNonLooping = false;
+    bool foundLooping = false;
     // Find music speed; it’s the speed of the fastest sfx
 	// While we are looping through this, find the lowest *valid* sfx length
     _audioState._musicChannel.master = _audioState._musicChannel.speed = -1;
@@ -168,6 +169,9 @@ void Audio::set_music_pattern(int pattern) {
         auto &sfx = _memory->sfx[n & 0x3f];
         bool looping = sfx.loopRangeStart < sfx.loopRangeEnd;
 	bool firstNonLooping = !looping && !foundNonLooping;
+	if (looping) {
+		foundLooping=true;
+	}
 	if (!looping) {
 		foundNonLooping=true;
 	}
@@ -200,7 +204,7 @@ void Audio::set_music_pattern(int pattern) {
         _audioState._sfxChannels[i].sfxId = n;
         _audioState._sfxChannels[i].offset = 0.f;
         _audioState._sfxChannels[i].phi = 0.f;
-        _audioState._sfxChannels[i].can_loop = false;
+        _audioState._sfxChannels[i].can_loop = foundLooping && foundNonLooping;
         _audioState._sfxChannels[i].is_music = true;
         _audioState._sfxChannels[i].prev_key = 24;
         _audioState._sfxChannels[i].prev_vol = 0.f;

--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -171,7 +171,7 @@ void Audio::set_music_pattern(int pattern) {
             _audioState._musicChannel.speed = std::max(1, (int)sfx.speed);
         }
 		
-		if(sfx.loopRangeStart >= sfx.loopRangeEnd){
+		if(sfx.loopRangeStart != 0 && sfx.loopRangeEnd == 0){
 			_audioState._musicChannel.length = std::min(_audioState._musicChannel.length, sfx.loopRangeStart);			
 		}
 		


### PR DESCRIPTION
Hey there. This fixes a bug in some music playback. noticed it in a game I'm working on:

Without this fix the title song only plays the drumloop once and cuts short the longer section.

the Audio code didn't seem super testable... Any insight into how to unit test this would be great. I haven't coded C++ in a while and a half.

even after this change the master channel detection doesn't seem 100% correct. I'd think it should look at the longest non-looping section, or the longest looping section if there are not non-looping sections. I can try to make this more robust in a follow-up.

here's the game where the title track wasn't playing right.
![planet p8](https://user-images.githubusercontent.com/272709/192441332-549b3d50-0c07-488b-8c54-04a900c444d3.png)

