### PR TITLE
More robust fix for music master channel selection

### DIFF
--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -179,7 +179,8 @@ void Audio::set_music_pattern(int pattern) {
 		length= sfx.loopRangeStart;			
 	}
 	else if (sfx.loopRangeEnd > sfx.loopRangeStart) {
-		length = sfx.loopRangeEnd;
+		// length = sfx.loopRangeEnd;
+    // pico 8 pretends like it's length 32!
 	}
 
 	uint16_t timeLength = length * std::max(1, (int)sfx.speed);;

--- a/test/audiotests.cpp
+++ b/test/audiotests.cpp
@@ -121,7 +121,7 @@ TEST_CASE("audio class behaves as expected") {
         CHECK_EQ(audioState->_sfxChannels[audioState->_musicChannel.master].sfxId, 1);
     }
 
-    SUBCASE("api_music picks shortest/fastest looping if all looping"){
+    SUBCASE("api_music picks fastest looping if all looping ignoring loop length"){
         picoRam.songs[3].data[0]=0;
         picoRam.songs[3].data[1]=1;
         picoRam.songs[3].data[2]=2;
@@ -135,7 +135,6 @@ TEST_CASE("audio class behaves as expected") {
         picoRam.sfx[2].speed = 3;
         picoRam.sfx[3].speed = 5;
         audio->api_music(3, 0, 0);
-        CHECK_EQ(audioState->_sfxChannels[audioState->_musicChannel.master].sfxId, 3);
+        CHECK_EQ(audioState->_sfxChannels[audioState->_musicChannel.master].sfxId, 2);
     }
-
 }


### PR DESCRIPTION
here's a more robust fix for music playing. This takes into account sfx length, sfx looping, sfx speed, and comes with some tests ^_^

confirmed it fixes my title song on this image and another song that was broken later on. Played a buncha random carts on my miyoo mini and it seemed good.

here's my cart that was not playing the whole song:
![planet p8](https://user-images.githubusercontent.com/272709/192689353-81beb6e0-f0ea-4d70-909f-c095e571d511.png)
