### PR TITLE
Music stats

### DIFF
--- a/source/picoluaapi.cpp
+++ b/source/picoluaapi.cpp
@@ -817,49 +817,60 @@ int stat(lua_State *L) {
         break;
         //16-19 audio sfx currently playing
         case 16:
+        case 46:
             lua_pushnumber(L, _audioForLuaApi->getCurrentSfxId(0));
             return 1;
         break;
         case 17:
+        case 47:
             lua_pushnumber(L, _audioForLuaApi->getCurrentSfxId(1));
             return 1;
         break;
         case 18:
+        case 48:
             lua_pushnumber(L, _audioForLuaApi->getCurrentSfxId(2));
             return 1;
         break;
         case 19:
+        case 49:
             lua_pushnumber(L, _audioForLuaApi->getCurrentSfxId(3));
             return 1;
         break;
         //20-23 note idx of sfx currently playing
         case 20:
+        case 50:
             lua_pushnumber(L, _audioForLuaApi->getCurrentNoteNumber(0));
             return 1;
         break;
         case 21:
+        case 51:
             lua_pushnumber(L, _audioForLuaApi->getCurrentNoteNumber(1));
             return 1;
         break;
         case 22:
+        case 52:
             lua_pushnumber(L, _audioForLuaApi->getCurrentNoteNumber(2));
             return 1;
         break;
         case 23:
+        case 53:
             lua_pushnumber(L, _audioForLuaApi->getCurrentNoteNumber(3));
             return 1;
         break;
         //current music pattern
         case 24:
+        case 54:
             lua_pushnumber(L, _audioForLuaApi->getCurrentMusic());
             return 1;
         break;
         //current music count
         case 25:
+        case 55:
             lua_pushnumber(L, _audioForLuaApi->getMusicPatternCount());
             return 1;
         break;
         //current music tick count
+        case 56:
         case 26:
             lua_pushnumber(L, _audioForLuaApi->getMusicTickCount());
             return 1;

--- a/test/picoluaapitests.cpp
+++ b/test/picoluaapitests.cpp
@@ -1,0 +1,167 @@
+#include "doctest.h"
+#include "stubhost.h"
+#include "../source/picoluaapi.h"
+#include "../source/fontdata.h"
+#include "../source/Input.h"
+#include "../source/vm.h"
+
+//extern "C" {
+  #include <lua.h>
+  #include <lauxlib.h>
+  #include <lualib.h>
+//}
+
+TEST_CASE("audio stats") {
+  // setup
+  PicoRam picoRam;
+  picoRam.Reset();
+  Audio* audio = new Audio(&picoRam);
+  std::string fontdata = get_font_data();
+  Graphics* graphics = new Graphics(fontdata, &picoRam);
+  //audioState_t* audioState = audio->getAudioState();
+  Input * input = new Input(&picoRam);
+  StubHost* stubHost = new StubHost();
+  Vm* vm = new Vm(stubHost, &picoRam, graphics, input, audio);
+  initPicoApi(&picoRam, graphics,  input, vm, audio);
+  lua_State *L = luaL_newstate();
+
+  SUBCASE("get sfx 0") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 16);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 5);
+  }
+  SUBCASE("get sfx 1") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 17);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 6);
+  }
+  SUBCASE("get sfx 2") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 18);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 7);
+  }
+  SUBCASE("get sfx 3") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 19);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 8);
+  }
+
+  SUBCASE("get sfx 0 updated") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 46);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 5);
+  }
+  SUBCASE("get sfx 1 updated") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 47);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 6);
+  }
+  SUBCASE("get sfx 2 updated") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 48);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 7);
+  }
+  SUBCASE("get sfx 3 updated") {
+    audio->api_sfx(5,0,0);
+    audio->api_sfx(6,1,0);
+    audio->api_sfx(7,2,0);
+    audio->api_sfx(8,3,0);
+
+    lua_pushnumber(L, 49);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 8);
+  }
+
+  SUBCASE("get note 0") {
+    audio->api_sfx(5,0,0);
+    lua_pushnumber(L, 20);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 0);
+  }
+
+  SUBCASE("get note 0 updated") {
+    audio->api_sfx(5,0,0);
+    lua_pushnumber(L, 20);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 0);
+  }
+
+  SUBCASE("get music") {
+    audio->api_music(5,0,0);
+    lua_pushnumber(L, 24);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 5);
+
+  }
+
+  SUBCASE("get music updated") {
+    audio->api_music(5,0,0);
+    lua_pushnumber(L, 54);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 5);
+  }
+
+  SUBCASE("get music pattern count") {
+    audio->api_music(5,0,0);
+    lua_pushnumber(L, 25);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 0);
+  }
+
+  SUBCASE("get music pattern count updated") {
+    audio->api_music(5,0,0);
+    lua_pushnumber(L, 55);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 0);
+  }
+
+  SUBCASE("get music tick count") {
+    audio->api_music(5,0,0);
+    lua_pushnumber(L, 26);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 0);
+  }
+
+  SUBCASE("get music tick count updated") {
+    audio->api_music(5,0,0);
+    lua_pushnumber(L, 56);
+    stat(L);
+    CHECK_EQ((int) lua_tonumber(L, -1), 0);
+  }
+
+}


### PR DESCRIPTION
Pico 8 has deprecated the stats for music and sfx and created new ones at +30 that work better. From the fake-08's point of view it's probably best to just copy the stats over for now to get it working. the exact nuances of timing that pico-8 was trying to fix (and a bug in a certain version) shouldn't matter.