### PR TITLE
Fix indentation in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Build
         run: make tests
-  
+
   xbox-series-libretro:
     name: Xbox Series Libretro
     runs-on: windows-latest
@@ -48,141 +48,141 @@ jobs:
           path: |
             platform/libretro/fake08_libretro.dll
 
- threeDS:
-   name: 3DS
-   runs-on: ubuntu-latest
+  threeDS:
+    name: 3DS
+    runs-on: ubuntu-latest
 
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v3
-       with:
-         submodules : recursive
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules : recursive
 
-     - name: Build
-       run: |
-         docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir devkitpro/devkitarm /bin/bash -ex /build_dir/.github/workflows/build3ds.sh
-     
-     - uses: actions/upload-artifact@v3
-       with:
-         name: Nintendo 3DS
-         path: |
-           platform/3ds/*.3dsx
-           platform/3ds/*.cia
+      - name: Build
+        run: |
+          docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir devkitpro/devkitarm /bin/bash -ex /build_dir/.github/workflows/build3ds.sh
 
- switch-standalone:
-   name: Switch
-   runs-on: ubuntu-latest
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Nintendo 3DS
+          path: |
+            platform/3ds/*.3dsx
+            platform/3ds/*.cia
 
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v3
-       with:
-         submodules : recursive
+  switch-standalone:
+    name: Switch
+    runs-on: ubuntu-latest
 
-     - name: Build
-       run: |
-         docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir devkitpro/devkita64 /bin/bash -ex /build_dir/.github/workflows/buildSwitch.sh
-     - uses: actions/upload-artifact@v3
-       with:
-         name: Nintendo Switch
-         path: |
-           platform/switch/*.nro
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules : recursive
 
- wiiu-standalone:
-   name: WiiU
-   runs-on: ubuntu-latest
+      - name: Build
+        run: |
+          docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir devkitpro/devkita64 /bin/bash -ex /build_dir/.github/workflows/buildSwitch.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Nintendo Switch
+          path: |
+            platform/switch/*.nro
 
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v3
-       with:
-         submodules : recursive
+  wiiu-standalone:
+    name: WiiU
+    runs-on: ubuntu-latest
 
-     - name: Build
-       run: |
-         docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir jondbell/devkitppc-wiiu-sdl2 /bin/bash -ex /build_dir/.github/workflows/buildWiiU.sh
-     - uses: actions/upload-artifact@v3
-       with:
-         name: Nintendo Wii U
-         path: |
-           platform/wiiu/*.rpx
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules : recursive
 
- vita-standalone:
-   name: Vita
-   runs-on: ubuntu-latest
+      - name: Build
+        run: |
+          docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir jondbell/devkitppc-wiiu-sdl2 /bin/bash -ex /build_dir/.github/workflows/buildWiiU.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Nintendo Wii U
+          path: |
+            platform/wiiu/*.rpx
 
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v3
-       with:
-         submodules : recursive
+  vita-standalone:
+    name: Vita
+    runs-on: ubuntu-latest
 
-     - name: Build
-       run: |
-         docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir gnuton/vitasdk-docker:20220413 /bin/sh -ex /build_dir/.github/workflows/buildVita.sh
-     - uses: actions/upload-artifact@v3
-       with:
-         name: PS Vita
-         path: |
-           platform/vita/*.vpk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules : recursive
 
- bittboy-standalone:
-   name: Bittboy
-   runs-on: ubuntu-latest
+      - name: Build
+        run: |
+          docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir gnuton/vitasdk-docker:20220413 /bin/sh -ex /build_dir/.github/workflows/buildVita.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: PS Vita
+          path: |
+            platform/vita/*.vpk
 
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v3
-       with:
-         submodules : recursive
+  bittboy-standalone:
+    name: Bittboy
+    runs-on: ubuntu-latest
 
-     - name: Build
-       run: |
-         docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir mcejp/arm-miyoo-linux-musleabi-gcc /bin/sh -ex /build_dir/.github/workflows/buildBittboy.sh
-     - uses: actions/upload-artifact@v3
-       with:
-         name: Bittboy
-         path: |
-           platform/bittboy/FAKE08
-           platform/bittboy/pico8.elf
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules : recursive
 
- miyoomini-standalone:
-   name: MiyooMini
-   runs-on: ubuntu-latest
+      - name: Build
+        run: |
+          docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir mcejp/arm-miyoo-linux-musleabi-gcc /bin/sh -ex /build_dir/.github/workflows/buildBittboy.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Bittboy
+          path: |
+            platform/bittboy/FAKE08
+            platform/bittboy/pico8.elf
 
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v3
-       with:
-         submodules : recursive
+  miyoomini-standalone:
+    name: MiyooMini
+    runs-on: ubuntu-latest
 
-     - name: Build
-       run: |
-         docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir jondbell/union-miyoomini-toolchain /bin/sh -ex /build_dir/.github/workflows/buildMiyooMini.sh
-     - uses: actions/upload-artifact@v3
-       with:
-         name: MiyooMini
-         path: |
-           platform/miyoomini/FAKE08
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules : recursive
 
- opendingux-standalone:
-   name: Opendingux
-   runs-on: ubuntu-latest
+      - name: Build
+        run: |
+          docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir jondbell/union-miyoomini-toolchain /bin/sh -ex /build_dir/.github/workflows/buildMiyooMini.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: MiyooMini
+          path: |
+            platform/miyoomini/FAKE08
 
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v3
-       with:
-         submodules : recursive
+  opendingux-standalone:
+    name: Opendingux
+    runs-on: ubuntu-latest
 
-     - name: Build
-       run: |
-         docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir jondbell/gcw0 /bin/sh -ex /build_dir/.github/workflows/buildGcw0.sh
-     - uses: actions/upload-artifact@v3
-       with:
-         name: Gcw0
-         path: |
-           platform/gcw0/fake08_gcw0.opk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules : recursive
+
+      - name: Build
+        run: |
+          docker run -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/build_dir jondbell/gcw0 /bin/sh -ex /build_dir/.github/workflows/buildGcw0.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Gcw0
+          path: |
+            platform/gcw0/fake08_gcw0.opk
 
   android-libretro:
     name: android-libretro
@@ -214,7 +214,7 @@ jobs:
             platform/libretro/libs/libfake08-arm64.so
             platform/libretro/libs/libfake08-arm32.so
             platform/libretro/fake08_libretro.info
-  
+
   miyoomini-libretro:
     name: MiyooMini-libretro
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Actions currently fail on the libnx-libretro-rebased branch: https://github.com/jtothebell/fake-08/actions/runs/6115996507

Idk much about YAML but looks like indentation is important? Actions pass fine after that change as you can see here: https://github.com/bslenul/fake-08/actions/runs/6130354769