### PR TITLE
Fix __f08_menu_items index 1 never used

### DIFF
--- a/source/p8GlobalLuaFunctions.h
+++ b/source/p8GlobalLuaFunctions.h
@@ -153,8 +153,8 @@ function menuitem(index, label, callback)
         callback = nil
     end
 
-    __f08_menu_items[index + 1][1] = label
-    __f08_menu_items[index + 1][2] = callback
+    __f08_menu_items[index][1] = label
+    __f08_menu_items[index][2] = callback
 end
 
 function __addbreadcrumb(label, carttoload)
@@ -185,7 +185,7 @@ function __f08_menu_update()
         until __f08_menu_items[__f08_menu_selected][1] ~= nil
     end
 
-    if btnp(2) and __f08_menu_selected > 1 then
+    if btnp(2) and __f08_menu_selected > 0 then
         repeat
             __f08_menu_selected = __f08_menu_selected - 1
         until __f08_menu_items[__f08_menu_selected][1] ~= nil


### PR DESCRIPTION
I'm not familiar with Lua.

It seems like that index 1 of __f08_menu_items never used. If a game has 5 menu item, "reset cart" will be  overwrited. 

Tested with Praxis Fighter X-2
