### PR TITLE
Fix vibrato effect: correct sawtooth to triangle wave modulation

### DIFF
--- a/source/Audio.cpp
+++ b/source/Audio.cpp
@@ -474,10 +474,10 @@ void Audio::update_sfx_state(sfx_state& cur_sfx, z8::synth_param& new_synth,
             }
             case FX_VIBRATO:
             {
-                // 7.5f and 0.25f were found empirically by matching
-                // frequency graphs of PICO-8 instruments.
-                float t = (float)(fabs(fmod(7.5 * offset / offset_per_second, 1.0)) - 0.5) - 0.25f;
-                // Vibrato half a semi-tone, so multiply by pow(2,1/12)
+                // Triangle wave modulation at 7.5 Hz, depth = half a semitone.
+                // The original code had fabs() wrapping only fmod(), producing
+                // a sawtooth modulation. Correct form: fabs(fmod(...) - 0.5).
+                float t = (float)(fabs(fmod(7.5 * offset / offset_per_second, 1.0) - 0.5) - 0.25);
                 freq = lerp(freq, freq * 1.059463094359f, t);
                 break;
             }

--- a/test/audiotests.cpp
+++ b/test/audiotests.cpp
@@ -2,10 +2,13 @@
 #include "../source/Audio.h"
 #include "../source/PicoRam.h"
 #include "../source/cart.h"
-#include <iostream>
+#include <cmath>
+#include <cstdlib>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 typedef struct WAV_HEADER {
   /* RIFF Chunk Descriptor */
@@ -50,6 +53,74 @@ void write_wav(std::istream *in, const char *output_filename) {
     in->read(reinterpret_cast<char *>(&d), sizeof(int16_t));
     out.write(reinterpret_cast<char *>(&d), sizeof(int16_t));
   }
+}
+
+TEST_CASE("vibrato produces triangle wave modulation") {
+    PicoRam picoRam;
+    picoRam.Reset();
+    Audio* audio = new Audio(&picoRam);
+
+    // Set up SFX 0: single note with vibrato effect, square wave for easy analysis
+    // Pitch 24 (C-2), waveform 3 (square), volume 7, effect 2 (vibrato)
+    for (int n = 0; n < 32; n++) {
+        picoRam.sfx[0].notes[n].setKey(24);
+        picoRam.sfx[0].notes[n].setWaveform(3);
+        picoRam.sfx[0].notes[n].setVolume(7);
+        picoRam.sfx[0].notes[n].setEffect(FX_VIBRATO);
+    }
+    picoRam.sfx[0].speed = 16;
+
+    audio->api_sfx(0, 0, 0, 31);
+
+    // Generate 1 second of audio (22050 samples)
+    const int num_samples = 22050;
+    int16_t samples[num_samples];
+    audio->FillMonoAudioBuffer(samples, 0, num_samples);
+
+    // Measure zero-crossing intervals to detect pitch modulation shape.
+    // Vibrato modulates the pitch, so zero-crossing intervals vary over
+    // time. With correct triangle modulation, intervals change smoothly.
+    // With the sawtooth bug, intervals jump abruptly at cycle boundaries.
+    //
+    // Collect zero-crossing intervals and check that consecutive intervals
+    // never jump by more than a threshold (smooth modulation).
+    std::vector<int> zc_intervals;
+    int last_zc = -1;
+    for (int i = 1; i < num_samples; i++) {
+        if ((samples[i-1] <= 0 && samples[i] > 0)) {
+            if (last_zc >= 0) {
+                zc_intervals.push_back(i - last_zc);
+            }
+            last_zc = i;
+        }
+    }
+
+    // With vibrato at C-2 (~261 Hz), we expect ~261 zero crossings/sec,
+    // so ~261 intervals in 1 second. Check we got a reasonable number.
+    CHECK(zc_intervals.size() > 100);
+
+    // Find the maximum jump between consecutive zero-crossing intervals.
+    // Triangle modulation: intervals change by ~1 sample between crossings.
+    // Sawtooth bug: intervals jump by several samples at the discontinuity.
+    int max_interval_jump = 0;
+    for (size_t i = 1; i < zc_intervals.size(); i++) {
+        int jump = std::abs(zc_intervals[i] - zc_intervals[i-1]);
+        if (jump > max_interval_jump) max_interval_jump = jump;
+    }
+
+    // With triangle vibrato, max jump should be small (<=4 samples).
+    // With sawtooth bug, jumps of 8+ samples occur at cycle boundaries.
+    CHECK(max_interval_jump <= 5);
+
+    // Also verify the signal is non-silent (vibrato didn't kill the output)
+    float rms = 0;
+    for (int i = 0; i < num_samples; i++) {
+        rms += (float)samples[i] * samples[i];
+    }
+    rms = std::sqrt(rms / num_samples);
+    CHECK(rms > 100.0f);
+
+    delete audio;
 }
 
 TEST_CASE("audio class behaves as expected") {


### PR DESCRIPTION
The vibrato effect (FX_VIBRATO) was producing a sawtooth modulation instead of a triangle wave due to incorrect parenthesization of fabs().

Before: fabs(fmod(...)) - 0.5  →  sawtooth (always positive fmod, then shift)
After:  fabs(fmod(...) - 0.5)  →  triangle (fold the centered ramp)

This caused audibly wrong pitch swings — choppy big swings instead of smooth reversals. Listen to reference PICO-8, current fake-08 and the results after this patch here: https://github.com/ysamlan/fake-08/tree/fix-vibrato-modulation-demo/cleanroom-spec/vibrato-demo.

Also added unit test that verifies smooth pitch modulation by measuring zero-crossing interval consistency.

- [x] This pull request is for a single Feature or BugFix
- [x] Your code builds clean without any errors on all platforms
- [x] You have added unit tests (if this is a change to the core Pico 8 emulator)
