### PR TITLE
Load cart synchronously in retro_load_game

### DIFF
--- a/platform/libretro/libretro.cpp
+++ b/platform/libretro/libretro.cpp
@@ -748,7 +748,7 @@ EXPORT bool retro_load_game(struct retro_game_info const *info)
     check_variables(true);
 
     if (!info) {
-        _vm->QueueCartChange("__FAKE08-BIOS.p8");
+        _vm->LoadCart("__FAKE08-BIOS.p8");
         return true;
     }
 
@@ -760,10 +760,10 @@ EXPORT bool retro_load_game(struct retro_game_info const *info)
 
     if (info->size > 0) {
         const unsigned char* data = reinterpret_cast<const unsigned char*>(info->data);
-        _vm->QueueCartChange(data, info->size);
+        _vm->LoadCart(data, info->size);
     }
     else {
-        _vm->QueueCartChange(info->path);
+        _vm->LoadCart(info->path);
     }
 
     return true;


### PR DESCRIPTION
The libretro core defers cart loading by calling `QueueCartChange()` inside `retro_load_game()`. The actual `LoadCart()` doesn't run until the first `Vm::Step()` inside `retro_run()`, one frame later.

This violates the libretro contract — `retro_load_game()` is expected to fully load the game before returning — and it breaks save state resume.

**The bug**

When RetroArch resumes a session with an auto-loaded save state, the call order is:

1. `retro_load_game()` — currently just queues the cart, doesn't load it
2. `retro_unserialize()` — tries to restore VM state against a cart that isn't loaded yet, and the core crashes
3. `retro_run()` → `Vm::Step()` — never reached

The same ordering applies to anything else a frontend may legitimately do between `retro_load_game()` and the first `retro_run()` (cheats, netplay sync, etc.).

**Fix**

Call `LoadCart()` directly in `retro_load_game()` instead of `QueueCartChange()`. The `Vm` already exposes both methods with matching signatures (`source/vm.h:77-78`), and `Vm::Step()`'s deferred-load path is unchanged for the `retro_reset` / in-game cart-switch cases that legitimately need queuing.

Three-line change in `platform/libretro/libretro.cpp`.