### PR TITLE
Fix Emscripten build target for static WebAssembly linking and IDBFS

### DIFF
--- a/platform/libretro/Makefile
+++ b/platform/libretro/Makefile
@@ -105,9 +105,9 @@ else ifneq (,$(findstring qnx,$(platform)))
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
 else ifeq ($(platform), emscripten)
-   TARGET := $(TARGET_NAME)_libretro_emscripten.bc
-   fpic := -fPIC
-   SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
+   TARGET := fake08.js
+   fpic := 
+   SHARED := -lidbfs.js --no-entry -s EXPORT_ALL=1 -s MODULARIZE=1 -s EXPORT_NAME=EJS_Runtime -s EXPORTED_RUNTIME_METHODS="['cwrap','ccall','setValue','getValue','FS']"
 else ifeq ($(platform), vita)
    TARGET := $(TARGET_NAME)_vita.a
    CC = arm-vita-eabi-gcc


### PR DESCRIPTION
Thank you for your contribution to the Fake-08 
Before submitting this PR, please make sure:

- [x] This pull request is for a single Feature or BugFix
- [x] Your code builds clean without any errors on all platforms
- [x] You have added unit tests (if this is a change to the core Pico 8 emulator)

### Description
This PR fixes the `emscripten` platform build target so it can be successfully compiled and integrated into web frontends like EmulatorJS.

The previous configuration lacked critical flags required for modular, async web integration:
- Added `--no-entry` to bypass non-existent standalone executable entry points.
- Linked the browser filesystem layer (`-lidbfs.js`) to support persistent save states.
- Exported core runtime methods (`cwrap`, `ccall`, `setValue`, `getValue`, `FS`) necessary for frontend framework interaction.
- Enabled native Emscripten modularization (`MODULARIZE=1`).

These changes are isolated strictly within the Emscripten platform conditional block and do not impact compilation paths for standard native architectures.